### PR TITLE
feat: unique ids for category, project and work package

### DIFF
--- a/OpenProjectImporter/CHANGELOG.md
+++ b/OpenProjectImporter/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5
+
+- Introduces unique IDs for category and project.
+
 # 1.2
 
 - Deeply nested projects are now imported correctly. The topmost project is always used as the category.

--- a/OpenProjectImporter/plugin.json
+++ b/OpenProjectImporter/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openproject_importer",
   "tymeMinVersion": "2024.11",
-  "version": "1.4",
+  "version": "1.5",
   "type": "import",
   "author": "Lars Malewski",
   "authorUrl": "https://github.com/tyme-app/plugins/tree/main/OpenProjectImporter",

--- a/OpenProjectImporter/script.js
+++ b/OpenProjectImporter/script.js
@@ -239,7 +239,6 @@ class OpenProjectWorkPackage {
     tymeTask.name = this.createTaskName();
     tymeTask.project = Project.fromID(this.project.tymeProjectId);
     tymeTask.isCompleted = this.isCompleted;
-    tymeTask.isCompleted = this.isCompleted ?? false;
     tymeTask.startDate = this.startDate;
     tymeTask.dueDate = this.dueDate;
     tymeTask.plannedDuration = this.plannedDuration;
@@ -367,7 +366,7 @@ class OpenProjectApiClient {
       this.loadStatuses();
     }
 
-    return this.statuses.find(status => status._links.self.href == statusHref).isClosed;
+    return this.statuses.find(status => status._links.self.href === statusHref)?.isClosed ?? false;
   }
 
   /**

--- a/OpenProjectImporter/script.js
+++ b/OpenProjectImporter/script.js
@@ -165,7 +165,7 @@ class OpenProjectProject {
   createOrUpdateProject() {
     let tymeProject = this.getProject();
     tymeProject.name = this.name;
-    tymeProject.isCompleted = !this.active;
+    tymeProject.isCompleted = this.isCompleted;
     tymeProject.category = this.category ? Category.fromID(this.category.tymeCategoryId) : null;
   }
 }

--- a/OpenProjectImporter/script.js
+++ b/OpenProjectImporter/script.js
@@ -1,4 +1,32 @@
 /**
+ * Tyme Project object.
+ * @typedef {Object} Category
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} isCompleted
+ */
+
+/**
+ * Tyme Project object.
+ * @typedef {Object} Project
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} isCompleted
+ */
+
+/**
+ * Tyme TimedTask object.
+ * @typedef {Object} TimedTask
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} isCompleted
+ * @property {number|null} [plannedDuration]
+ * @property {Date|null} [startDate]
+ * @property {Date|null} [dueDate]
+ * @property {Project} project
+ */
+
+/**
  * OpenProject category.
  */
 class OpenProjectCategory {
@@ -13,17 +41,47 @@ class OpenProjectCategory {
   }
 
   /**
-   * Tyme category ID of this project.
+   * Tyme category ID of this category.
+   * @returns {string}
    */
   get tymeCategoryId() {
+    return 'openproject-c' + this.id;
+  }
+
+  /**
+   * Tyme category ID of this category.
+   * @deprecated This is the old format. Use the `tymeCategoryId` instead.
+   * @returns {string}
+   */
+  get oldTymeCategoryId() {
     return 'openproject-' + this.id;
+  }
+
+  /**
+   * Tyme category object for this category.
+   * @returns {Category} Tyme `Category` object.
+   */
+  getCategory() {
+    const category = Category.fromID(this.tymeCategoryId);
+    if (category) {
+      return category;
+    }
+
+    // Check for old category and update (can be removed in the future)
+    const oldCategory = Category.fromID(this.oldTymeCategoryId);
+    if (oldCategory) {
+      oldCategory.id = this.tymeCategoryId;
+      return oldCategory;
+    }
+
+    return Category.create(this.tymeCategoryId);
   }
 
   /**
    * Create or update an existing category in Tyme.
    */
   createOrUpdateCategory() {
-    let tymeCategory = Category.fromID(this.tymeCategoryId) ?? Category.create(this.tymeCategoryId);
+    let tymeCategory = this.getCategory();
     tymeCategory.name = this.name;
   }
 }
@@ -69,14 +127,43 @@ class OpenProjectProject {
    * @returns {string}
    */
   get tymeProjectId() {
+    return 'openproject-p' + this.projectId;
+  }
+
+  /**
+   * Tyme project ID of this project.
+   * @deprecated This is the old format. Use the `tymeProjectId` instead.
+   * @returns {string}
+   */
+  get oldTymeProjectId() {
     return 'openproject-' + this.projectId;
+  }
+
+  /**
+   * Tyme project object for this project.
+   * @returns {Project} Tyme `Project` object.
+   */
+  getProject() {
+    const project = Project.fromID(this.tymeProjectId);
+    if (project) {
+      return project;
+    }
+
+    // Check for old project and update (can be removed in the future)
+    const oldProject = Project.fromID(this.oldTymeProjectId);
+    if (oldProject) {
+      oldProject.id = this.tymeProjectId;
+      return oldProject;
+    }
+
+    return Project.create(this.tymeProjectId);
   }
 
   /**
    * Create or update an existing project in Tyme.
    */
   createOrUpdateProject() {
-    let tymeProject = Project.fromID(this.tymeProjectId) ?? Project.create(this.tymeProjectId);
+    let tymeProject = this.getProject();
     tymeProject.name = this.name;
     tymeProject.isCompleted = !this.active;
     tymeProject.category = this.category ? Category.fromID(this.category.tymeCategoryId) : null;
@@ -88,9 +175,12 @@ class OpenProjectProject {
  */
 class OpenProjectWorkPackage {
   /**
-   *
+   * Create an OpenProject work package.
    * @param {number} id Work package ID.
    * @param {string} name Name of the work package.
+   * @param {string} start Start date of the work package.
+   * @param {string} due Due date of the work package.
+   * @param {string} estimatedTime Estimated time of the work package.
    * @param {boolean} isCompleted Indicates if this work package is completed.
    * @param {OpenProjectProject} project Project of this work package.
    */
@@ -144,6 +234,7 @@ class OpenProjectWorkPackage {
    * Create or update an existing task in Tyme with the data from the work package.
    */
   createOrUpdateTask() {
+    /** @type {TimedTask} */
     let tymeTask = TimedTask.fromID(this.workPackageId) ?? TimedTask.create(this.workPackageId);
     tymeTask.name = this.createTaskName();
     tymeTask.project = Project.fromID(this.project.tymeProjectId);


### PR DESCRIPTION
Changes the format of the category and project IDs so that they are not overlapping. Updates existing categories and projects so there shouldn't be any problems with existing data.