### PR TITLE
fix: fetch status to close completed work items

### DIFF
--- a/JiraImporter/CHANGELOG.md
+++ b/JiraImporter/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4
+
+- Fixed an issue that prevented closed work items from being marked as completed.
+
 # 1.3
 
 - Switched to new Jira API endpoint.

--- a/JiraImporter/plugin.json
+++ b/JiraImporter/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "jira_importer",
   "tymeMinVersion": "2024.11",
-  "version": "1.3",
+  "version": "1.4",
   "type": "import",
   "author": "Lars Malewski",
   "authorUrl": "https://github.com/tyme-app/plugins/tree/main/JiraImporter",

--- a/JiraImporter/script.js
+++ b/JiraImporter/script.js
@@ -273,7 +273,7 @@ class JiraApiClient {
    */
   get fieldsToFetch() {
     // Base fields
-    const fields = ['key', 'summary', 'project'];
+    const fields = ['key', 'summary', 'project', 'status'];
 
     // Add user selected fields, if selected
     if (Form.startDateField) {


### PR DESCRIPTION
Fixes an issue that prevented closed work items in Jira from being marked as completed in Tyme.